### PR TITLE
ci: get pre-commit style-check to green on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 default_stages: [pre-commit]
 
+# subprojects/ is upstream-controlled (kakadujs from Chris Hafey + the
+# licensed Kakadu SDK tree). We do not own its style and must not modify
+# it — exclude from all pre-commit hooks.
+exclude: '^subprojects/'
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/afterbuild.sh
+++ b/afterbuild.sh
@@ -1,11 +1,13 @@
-#!/bin/zsh
+#!/bin/bash
+set -euo pipefail
+shopt -s nullglob
 cd build/apps
 ln -sf ../post_processing_stages/hailo/hailo-postproc.so ./
 ln -sf ../post_processing_stages/core-postproc.so ./
 ln -sf ../post_processing_stages/opencv-postproc.so ./
-# Preview backends are dynamically loaded since upstream v1.8.0 — the
-# (N) glob qualifier silently drops backends that weren't built.
-for so in ../preview/*-preview.so(N) ../encoder/*-encoder.so(N); do
+# Preview / encoder backends are dynamically loaded since upstream v1.8.0;
+# nullglob silently drops backends that weren't built.
+for so in ../preview/*-preview.so ../encoder/*-encoder.so; do
     ln -sf "$so" ./
 done
 ln -sf /usr/share/rpi-camera-assets/*.json .

--- a/apps/rpicam_hello.cpp
+++ b/apps/rpicam_hello.cpp
@@ -18,7 +18,14 @@
 
 using namespace std::placeholders;
 
-enum progression { LRCP, RLCP, RPCL, PCRL, CPRL };
+enum progression
+{
+	LRCP,
+	RLCP,
+	RPCL,
+	PCRL,
+	CPRL
+};
 
 // The main event loop for the application.
 
@@ -28,11 +35,12 @@ static void event_loop(RPiCamApp &app)
 
 	app.OpenCamera();
 	app.ConfigureViewfinder();
-	
+
 	// Setup HTJ2K encoder
 	std::vector<uint8_t> encbuf; // codestream buffer
-  	encbuf.reserve(options->Get().viewfinder_width * options->Get().viewfinder_height * 3);
-  	const FrameInfo finfo = {static_cast<uint16_t>(options->Get().viewfinder_width), static_cast<uint16_t>(options->Get().viewfinder_height), 8, 3, false};
+	encbuf.reserve(options->Get().viewfinder_width * options->Get().viewfinder_height * 3);
+	const FrameInfo finfo = { static_cast<uint16_t>(options->Get().viewfinder_width),
+							  static_cast<uint16_t>(options->Get().viewfinder_height), 8, 3, false };
 	// HTJ2KEncoder encoder(encbuf, finfo); // encoder instance
 	HT_Encoder htenc(encbuf, finfo, options);
 

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -19,23 +19,15 @@
 
 #include "simple_tcp.hpp"
 
-uint8_t hotfix_for_mainheader[32] = {
-	0xFF,0x4F,0xFF,0x51,0x00,0x2F,0x40,0x00,
-	0x00,0x00,0x07,0x80,0x00,0x00,0x04,0x38,
-	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-	0x00,0x00,0x07,0x80,0x00,0x00,0x04,0x38
-};
+uint8_t hotfix_for_mainheader[32] = { 0xFF, 0x4F, 0xFF, 0x51, 0x00, 0x2F, 0x40, 0x00, 0x00, 0x00, 0x07,
+									  0x80, 0x00, 0x00, 0x04, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+									  0x00, 0x00, 0x00, 0x00, 0x07, 0x80, 0x00, 0x00, 0x04, 0x38 };
 class HT_Encoder
 {
 public:
-	HT_Encoder(std::vector<uint8_t> &encoded_, const FrameInfo &info, Options const *options) :
-        abortEncode_(false),
-        abortOutput_(false),
-        index_(0),
-        enc(encoded_, info),
-		buf(encoded_),
-		tcp_socket_("133.36.41.118", 4001),
-		tcp_connected_(false)
+	HT_Encoder(std::vector<uint8_t> &encoded_, const FrameInfo &info, Options const *options)
+		: abortEncode_(false), abortOutput_(false), index_(0), enc(encoded_, info), buf(encoded_),
+		  tcp_socket_("133.36.41.118", 4001), tcp_connected_(false)
 	{
 		tcp_connected_ = (tcp_socket_.create_client() >= 0);
 		if (!tcp_connected_)
@@ -174,7 +166,7 @@ private:
 				}
 			}
 		got_item:
-        // no need of callback
+			// no need of callback
 			// free(item.mem);
 			index++;
 		}
@@ -197,12 +189,11 @@ private:
 	std::thread encode_thread_[NUM_ENC_THREADS];
 	void encodeHTJ2K(EncodeItem &item, std::vector<uint8_t> &out, size_t &buffer_len)
 	{
-        enc.setSourceImage((uint8_t *)item.mem, item.info.width * item.info.height * 3);
-        enc.encode();
-        out = enc.getEncodedBytes();
-        // encoded_buffer = out.data();
-        buffer_len = out.size();
-
+		enc.setSourceImage((uint8_t *)item.mem, item.info.width * item.info.height * 3);
+		enc.encode();
+		out = enc.getEncodedBytes();
+		// encoded_buffer = out.data();
+		buffer_len = out.size();
 	}
 
 	struct OutputItem
@@ -217,7 +208,7 @@ private:
 	std::condition_variable output_cond_var_;
 	std::thread output_thread_;
 
-    HTJ2KEncoder enc; // encoder instance
+	HTJ2KEncoder enc; // encoder instance
 	std::vector<uint8_t> &buf;
 	simple_tcp tcp_socket_;
 	bool tcp_connected_;

--- a/encoder/simple_tcp.hpp
+++ b/encoder/simple_tcp.hpp
@@ -11,70 +11,86 @@
 #include <string>
 #include <vector>
 
-class simple_tcp {
-  int sockfd;
-  int client_sockfd;
-  sockaddr_in addr;
-  sockaddr_in from_addr;
+class simple_tcp
+{
+	int sockfd;
+	int client_sockfd;
+	sockaddr_in addr;
+	sockaddr_in from_addr;
 
- public:
-  simple_tcp(std::string address, int port) : sockfd(-1), client_sockfd(-1) {
-    addr.sin_family      = AF_INET;
-    addr.sin_addr.s_addr = inet_addr(address.c_str());
-    addr.sin_port        = htons(port);
-  }
+public:
+	simple_tcp(std::string address, int port) : sockfd(-1), client_sockfd(-1)
+	{
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = inet_addr(address.c_str());
+		addr.sin_port = htons(port);
+	}
 
-  ~simple_tcp() { this->destroy(); }
+	~simple_tcp()
+	{
+		this->destroy();
+	}
 
-  void destroy() {
-    close(client_sockfd);
-    close(sockfd);
-  }
+	void destroy()
+	{
+		close(client_sockfd);
+		close(sockfd);
+	}
 
-  int create_server() {
-    sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    // set option
-    int opt = 1;
-    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
-    // bind
-    bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
-    // listen
-    listen(sockfd, SOMAXCONN);
-    socklen_t len = sizeof(sockaddr_in);
-    client_sockfd = accept(sockfd, (struct sockaddr *)&from_addr, &len);
-    return sockfd;
-  }
+	int create_server()
+	{
+		sockfd = socket(AF_INET, SOCK_STREAM, 0);
+		// set option
+		int opt = 1;
+		setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+		// bind
+		bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
+		// listen
+		listen(sockfd, SOMAXCONN);
+		socklen_t len = sizeof(sockaddr_in);
+		client_sockfd = accept(sockfd, (struct sockaddr *)&from_addr, &len);
+		return sockfd;
+	}
 
-  int create_client() {
-    sockfd  = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0) {
-      return -1;
-    }
-    int nodelay = 1;
-    setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-    if (connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
-      close(sockfd);
-      sockfd = -1;
-      return -1;
-    }
-    return 0;
-  }
+	int create_client()
+	{
+		sockfd = socket(AF_INET, SOCK_STREAM, 0);
+		if (sockfd < 0)
+		{
+			return -1;
+		}
+		int nodelay = 1;
+		setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+		if (connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+		{
+			close(sockfd);
+			sockfd = -1;
+			return -1;
+		}
+		return 0;
+	}
 
-  int Rx(uint8_t *dst) {
-    std::vector<uint8_t> buf(5000000);
-    int len = 0;
-    int rsize = recv(client_sockfd, buf.data(), buf.size(), 0);
-    len += rsize;
-    while (rsize > 0) {
-      for (int i = 0; i < rsize; ++i) {
-        dst[i] = buf[i];
-      }
-      dst += rsize;
-      rsize = recv(client_sockfd, buf.data(), buf.size(), 0);
-      len += rsize;
-    }
-    return len;
-  }
+	int Rx(uint8_t *dst)
+	{
+		std::vector<uint8_t> buf(5000000);
+		int len = 0;
+		int rsize = recv(client_sockfd, buf.data(), buf.size(), 0);
+		len += rsize;
+		while (rsize > 0)
+		{
+			for (int i = 0; i < rsize; ++i)
+			{
+				dst[i] = buf[i];
+			}
+			dst += rsize;
+			rsize = recv(client_sockfd, buf.data(), buf.size(), 0);
+			len += rsize;
+		}
+		return len;
+	}
 
-  void Tx(uint8_t *src, size_t len) { send(sockfd, src, len, 0); }
+	void Tx(uint8_t *src, size_t len)
+	{
+		send(sockfd, src, len, 0);
+	}
 };

--- a/post_processing_stages/object_detect_draw_cv_stage.cpp
+++ b/post_processing_stages/object_detect_draw_cv_stage.cpp
@@ -78,7 +78,7 @@ bool ObjectDetectDrawCvStage::Process(CompletedRequestPtr &completed_request)
 	Mat tmp;
 	cvtColor(image, tmp, COLOR_YUV2BGR_I420);
 	// printf("orig: %x, before = %x", ptr, image.data); // for DEBUGGING address of ptr
-	
+
 	// Scalar colour = Scalar(255, 255, 255);
 	Scalar YELLOW = Scalar(0, 255, 255);
 	Scalar BLUE = Scalar(255, 178, 50);


### PR DESCRIPTION
## Summary
The `style-check` GitHub Action (`pre-commit run --all-files`) has been red on `main` since the upstream-sync merge. This PR brings it to green without touching upstream-controlled trees.

- **`.pre-commit-config.yaml`** — add a top-level `exclude: '^subprojects/'`. The `subprojects/` tree is upstream-owned (kakadujs from Chris Hafey + the licensed Kakadu SDK we must not modify). Linting it would diverge from upstream and add merge pain on every kakadujs sync.
- **`afterbuild.sh`** — `#!/bin/zsh` makes shellcheck refuse to scan the file (SC1071), so the script was silently exempt. The only zsh-ism was the `(N)` null-glob qualifier; swap to `#!/bin/bash` + `shopt -s nullglob`, plus `set -euo pipefail` so a failing `cd` aborts cleanly (also satisfies SC2164).
- **Auto-fixes on fork-controlled files** — `apps/rpicam_hello.cpp`, `encoder/ht_encoder.hpp`, `encoder/simple_tcp.hpp`, `post_processing_stages/object_detect_draw_cv_stage.cpp`: trailing whitespace, missing EOL, and `clang-format` normalization per the repo `.clang-format`. Pure whitespace/brace/indent changes; no semantics touched.

Verified locally: `pre-commit run --all-files` is green on this branch, and `meson compile -C build` still builds clean.

## Heads-up for PR #8
The clang-format reformat of `encoder/ht_encoder.hpp` and `encoder/simple_tcp.hpp` will conflict with the perf cleanup branch (`perf-rpicam-hello-cleanup` → PR #8). Once this PR lands, I'll rebase #8 onto the new `main` and resolve.

## Test plan
- [ ] CI `style-check` job passes on this PR
- [ ] `meson compile -C build` succeeds (verified locally)
- [ ] `./afterbuild.sh` still creates the expected symlinks under `build/apps/` after a fresh `meson setup --wipe build …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)