### PR TITLE
encoder: Persistent TCP with length-prefix framing

### DIFF
--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -106,11 +106,19 @@ private:
 				// printf("\n");
 			}
 			encode_time = (std::chrono::high_resolution_clock::now() - start_time);
-			// send codestream via persistent TCP connection (retry connect if not yet up)
+			// Send codestream via persistent TCP connection, framed as [u32 BE length][N bytes].
+			// On failure, drop the socket and reconnect on the next frame.
 			if (!tcp_connected_)
 				tcp_connected_ = (tcp_socket_.create_client() >= 0);
 			if (tcp_connected_)
-				tcp_socket_.Tx(buf.data(), buffer_len);
+			{
+				if (!tcp_socket_.SendFramed(buf.data(), static_cast<uint32_t>(buffer_len)))
+				{
+					LOG(1, "HT_Encoder: TCP send failed; reconnecting on next frame");
+					tcp_socket_.destroy();
+					tcp_connected_ = false;
+				}
+			}
 			printf("HT codestream size = %ld, time = %f\n", buffer_len, encode_time);
 			frames++;
 			// Don't return buffers until the output thread as that's where they're

--- a/encoder/simple_tcp.hpp
+++ b/encoder/simple_tcp.hpp
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -17,9 +18,10 @@ class simple_tcp
 	int client_sockfd;
 	sockaddr_in addr;
 	sockaddr_in from_addr;
+	bool is_server_;
 
 public:
-	simple_tcp(std::string address, int port) : sockfd(-1), client_sockfd(-1)
+	simple_tcp(std::string address, int port) : sockfd(-1), client_sockfd(-1), is_server_(false)
 	{
 		addr.sin_family = AF_INET;
 		addr.sin_addr.s_addr = inet_addr(address.c_str());
@@ -33,34 +35,71 @@ public:
 
 	void destroy()
 	{
-		close(client_sockfd);
-		close(sockfd);
+		if (client_sockfd >= 0)
+		{
+			close(client_sockfd);
+			client_sockfd = -1;
+		}
+		if (sockfd >= 0)
+		{
+			close(sockfd);
+			sockfd = -1;
+		}
+	}
+
+	void disconnect_client()
+	{
+		if (client_sockfd >= 0)
+		{
+			close(client_sockfd);
+			client_sockfd = -1;
+		}
+	}
+
+	int bind_listen()
+	{
+		is_server_ = true;
+		sockfd = socket(AF_INET, SOCK_STREAM, 0);
+		if (sockfd < 0)
+			return -1;
+		int opt = 1;
+		setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+		if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+			return -1;
+		if (listen(sockfd, SOMAXCONN) != 0)
+			return -1;
+		return 0;
+	}
+
+	int accept_one()
+	{
+		if (client_sockfd >= 0)
+		{
+			close(client_sockfd);
+			client_sockfd = -1;
+		}
+		socklen_t len = sizeof(sockaddr_in);
+		client_sockfd = accept(sockfd, (struct sockaddr *)&from_addr, &len);
+		return client_sockfd >= 0 ? 0 : -1;
 	}
 
 	int create_server()
 	{
-		sockfd = socket(AF_INET, SOCK_STREAM, 0);
-		// set option
-		int opt = 1;
-		setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
-		// bind
-		bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
-		// listen
-		listen(sockfd, SOMAXCONN);
-		socklen_t len = sizeof(sockaddr_in);
-		client_sockfd = accept(sockfd, (struct sockaddr *)&from_addr, &len);
-		return sockfd;
+		if (bind_listen() != 0)
+			return -1;
+		return accept_one() == 0 ? sockfd : -1;
 	}
 
 	int create_client()
 	{
+		is_server_ = false;
 		sockfd = socket(AF_INET, SOCK_STREAM, 0);
 		if (sockfd < 0)
-		{
 			return -1;
-		}
 		int nodelay = 1;
 		setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+		int keepalive = 1;
+		setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
 		if (connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 		{
 			close(sockfd);
@@ -70,11 +109,77 @@ public:
 		return 0;
 	}
 
+	bool is_connected() const
+	{
+		return is_server_ ? client_sockfd >= 0 : sockfd >= 0;
+	}
+
+	int active_fd() const
+	{
+		return is_server_ ? client_sockfd : sockfd;
+	}
+
+	bool send_all(const uint8_t *src, size_t len)
+	{
+		int fd = active_fd();
+		if (fd < 0)
+			return false;
+		size_t sent = 0;
+		while (sent < len)
+		{
+			ssize_t n = send(fd, src + sent, len - sent, MSG_NOSIGNAL);
+			if (n <= 0)
+				return false;
+			sent += static_cast<size_t>(n);
+		}
+		return true;
+	}
+
+	bool recv_all(uint8_t *dst, size_t len)
+	{
+		int fd = active_fd();
+		if (fd < 0)
+			return false;
+		size_t got = 0;
+		while (got < len)
+		{
+			ssize_t n = recv(fd, dst + got, len - got, 0);
+			if (n <= 0)
+				return false;
+			got += static_cast<size_t>(n);
+		}
+		return true;
+	}
+
+	bool SendFramed(const uint8_t *src, uint32_t len)
+	{
+		uint32_t len_be = htonl(len);
+		if (!send_all(reinterpret_cast<const uint8_t *>(&len_be), 4))
+			return false;
+		return send_all(src, len);
+	}
+
+	bool RecvFramed(std::vector<uint8_t> &dst, uint32_t &len)
+	{
+		uint32_t len_be = 0;
+		if (!recv_all(reinterpret_cast<uint8_t *>(&len_be), 4))
+			return false;
+		len = ntohl(len_be);
+		if (len > 64u * 1024u * 1024u)
+			return false;
+		if (dst.size() < len)
+			dst.resize(len);
+		return recv_all(dst.data(), len);
+	}
+
 	int Rx(uint8_t *dst)
 	{
 		std::vector<uint8_t> buf(5000000);
 		int len = 0;
-		int rsize = recv(client_sockfd, buf.data(), buf.size(), 0);
+		int fd = active_fd();
+		if (fd < 0)
+			return 0;
+		int rsize = recv(fd, buf.data(), buf.size(), 0);
 		len += rsize;
 		while (rsize > 0)
 		{
@@ -83,7 +188,7 @@ public:
 				dst[i] = buf[i];
 			}
 			dst += rsize;
-			rsize = recv(client_sockfd, buf.data(), buf.size(), 0);
+			rsize = recv(fd, buf.data(), buf.size(), 0);
 			len += rsize;
 		}
 		return len;
@@ -91,6 +196,6 @@ public:
 
 	void Tx(uint8_t *src, size_t len)
 	{
-		send(sockfd, src, len, 0);
+		send_all(src, len);
 	}
 };


### PR DESCRIPTION
## Summary

Replace the per-frame TCP connection in the HT_Encoder archive path with a single long-lived connection plus explicit `[u32 BE length][N bytes]` framing.

- `simple_tcp.hpp`: split `create_server()` into `bind_listen()` + `accept_one()` so the server can re-accept on disconnect without re-binding; add `send_all` / `recv_all` helpers that loop on partial transfers and use `MSG_NOSIGNAL` to suppress SIGPIPE on broken connections; add `SendFramed` / `RecvFramed` (4-byte big-endian length prefix); track server vs client role so the helpers pick the correct fd; set `SO_KEEPALIVE` on client connections.
- `ht_encoder.hpp`: send via `SendFramed`; on send failure, drop the socket and reconnect on the next frame instead of writing into a half-closed connection.
- The receiver-side `recv_tcp.cpp` on the deployment host (133.36.41.118) was updated in lockstep to consume the same wire format — out-of-tree, deployed via SSH.

The pre-refactor sender quietly kept the socket open across frames while the pre-refactor receiver expected one connection per frame, so frame 1 mostly worked and everything after it was undefined behaviour. After the refactor both ends agree on the wire format and ill-defined edge cases are gone.

## Test plan

- [x] `meson compile -C build` clean (`apps/rpicam-hello` rebuilds without warnings)
- [x] Receiver-side `recv_tcp` rebuilt and deployed at `133.36.41.118:/home/olab/20875-recv/`
- [x] Smoke test: two distinct payloads (533 and 1045 bytes) sent over a single persistent TCP connection — both saved byte-perfect on the receiver, payload md5 matched after skipping the 85-byte JPH header, both indexed in MongoDB
- [x] Backups of pre-refactor receiver source + binary kept on the deployment host (`*.bak2.20260429`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)