### PR TITLE
Decouple RTP fan-out from the person-detection gate

### DIFF
--- a/apps/rpicam_hello.cpp
+++ b/apps/rpicam_hello.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <chrono>
+#include <limits>
 
 #include "core/options.hpp"
 #include "core/rpicam_app.hpp"
@@ -46,6 +47,10 @@ static void event_loop(RPiCamApp &app)
 
 	app.StartCamera();
 
+	const int64_t archive_interval_us =
+		static_cast<int64_t>(options->Get().archive_min_interval_ms) * 1000;
+	int64_t last_archive_us = std::numeric_limits<int64_t>::min();
+
 	auto start_time = std::chrono::high_resolution_clock::now();
 	for (unsigned int count = 0;; count++)
 	{
@@ -72,17 +77,23 @@ static void event_loop(RPiCamApp &app)
 
 		std::vector<Detection> objects;
 		completed_request->post_process_metadata.Get("object_detect.results", objects);
-		bool encode = false;
+		bool person_detected = false;
 		for (auto const &v : objects)
 		{
 			if (v.name == "person" && v.confidence > 0.75)
 			{
-				encode = true;
+				person_detected = true;
 				break;
 			}
 		}
-		if (!encode)
-			continue;
+
+		const int64_t now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+									now.time_since_epoch())
+									.count();
+		const bool archive_this_frame =
+			person_detected && (now_us - last_archive_us >= archive_interval_us);
+		if (archive_this_frame)
+			last_archive_us = now_us;
 
 		libcamera::Stream *stream = app.ViewfinderStream();
 		BufferReadSync r(&app, completed_request->buffers[stream]);
@@ -90,7 +101,8 @@ static void event_loop(RPiCamApp &app)
 		const int w = options->Get().viewfinder_width;
 		const int h = options->Get().viewfinder_height;
 		cv::Mat frame(h * 3 / 2, w, CV_8UC1, buffer.data());
-		htenc.EncodeBuffer(1, w * h * 3 / 2, frame.data, app.GetStreamInfo(stream), 0);
+		htenc.EncodeBuffer(1, w * h * 3 / 2, frame.data, app.GetStreamInfo(stream), now_us,
+						   archive_this_frame);
 	}
 }
 

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -251,6 +251,8 @@ Options::Options()
 			"H.273 MatrixCoefficients written to the RTP Main packet (default 5 = BT.470BG/BT.601 525)")
 		("rtp-range", value<bool>(&v_->rtp_range)->default_value(true)->implicit_value(true),
 			"RTP VideoFullRangeFlag (default true = full range; false = narrow/limited)")
+		("archive-min-interval-ms", value<int>(&v_->archive_min_interval_ms)->default_value(1000),
+			"Minimum spacing between TCP archive snapshots when a person is detected, in ms (default 1000)")
 		("nopreview,n", value<bool>(&v_->nopreview)->default_value(false)->implicit_value(true),
 			"Do not show a preview window")
 		("preview,p", value<std::string>(&v_->preview)->default_value("0,0,0,0"),

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -243,6 +243,14 @@ Options::Options()
 			"Destination IP for the RFC 9828 RTP fan-out from HT_Encoder")
 		("rtp-port", value<int>(&v_->rtp_port)->default_value(6000),
 			"Destination UDP port for the RFC 9828 RTP fan-out from HT_Encoder")
+		("rtp-prims", value<int>(&v_->rtp_prims)->default_value(1),
+			"H.273 ColourPrimaries written to the RTP Main packet (default 1 = BT.709/sRGB)")
+		("rtp-trans", value<int>(&v_->rtp_trans)->default_value(13),
+			"H.273 TransferCharacteristics written to the RTP Main packet (default 13 = sRGB/IEC 61966-2-1)")
+		("rtp-mat", value<int>(&v_->rtp_mat)->default_value(5),
+			"H.273 MatrixCoefficients written to the RTP Main packet (default 5 = BT.470BG/BT.601 525)")
+		("rtp-range", value<bool>(&v_->rtp_range)->default_value(true)->implicit_value(true),
+			"RTP VideoFullRangeFlag (default true = full range; false = narrow/limited)")
 		("nopreview,n", value<bool>(&v_->nopreview)->default_value(false)->implicit_value(true),
 			"Do not show a preview window")
 		("preview,p", value<std::string>(&v_->preview)->default_value("0,0,0,0"),

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -239,6 +239,10 @@ Options::Options()
 			"Set the file name for configuring the post-processing")
 		("post-process-libs", value<std::string>(&v_->post_process_libs),
 			"Set a custom location for the post-processing library .so files")
+		("rtp-host", value<std::string>(&v_->rtp_host)->default_value("127.0.0.1"),
+			"Destination IP for the RFC 9828 RTP fan-out from HT_Encoder")
+		("rtp-port", value<int>(&v_->rtp_port)->default_value(6000),
+			"Destination UDP port for the RFC 9828 RTP fan-out from HT_Encoder")
 		("nopreview,n", value<bool>(&v_->nopreview)->default_value(false)->implicit_value(true),
 			"Do not show a preview window")
 		("preview,p", value<std::string>(&v_->preview)->default_value("0,0,0,0"),

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -339,6 +339,12 @@ struct OptsInternal
 	// RFC 9828 RTP destination for the live-monitoring fan-out in HT_Encoder.
 	std::string rtp_host;
 	int rtp_port;
+	// H.273 colorspace codes written into the Main packet header (S=1).
+	// Defaults are sYCC: BT.709 primaries, sRGB transfer, BT.601 matrix, full range.
+	int rtp_prims;
+	int rtp_trans;
+	int rtp_mat;
+	bool rtp_range;
 };
 
 struct Options

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -345,6 +345,9 @@ struct OptsInternal
 	int rtp_trans;
 	int rtp_mat;
 	bool rtp_range;
+	// Minimum spacing between TCP archive snapshots when person-detected.
+	// Independent of the RTP fan-out, which runs every encoded frame.
+	int archive_min_interval_ms;
 };
 
 struct Options

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -335,6 +335,10 @@ struct OptsInternal
 
 	std::string preview_libs;
 	std::string encoder_libs;
+
+	// RFC 9828 RTP destination for the live-monitoring fan-out in HT_Encoder.
+	std::string rtp_host;
+	int rtp_port;
 };
 
 struct Options

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -18,6 +18,12 @@
 #include "subprojects/kakadujs/src/HTJ2KEncoder.hpp"
 
 #include "simple_tcp.hpp"
+#include "rfc9828_packetizer.hpp"
+
+// RFC 9828 RTP destination for live monitoring. Independent of the TCP archive
+// destination; receiver is osamu620/OpenHTJ2K's rtp_recv (default :6000).
+static constexpr const char *RTP_DST_HOST = "127.0.0.1";
+static constexpr int RTP_DST_PORT = 6000;
 
 uint8_t hotfix_for_mainheader[32] = { 0xFF, 0x4F, 0xFF, 0x51, 0x00, 0x2F, 0x40, 0x00, 0x00, 0x00, 0x07,
 									  0x80, 0x00, 0x00, 0x04, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -27,11 +33,14 @@ class HT_Encoder
 public:
 	HT_Encoder(std::vector<uint8_t> &encoded_, const FrameInfo &info, Options const *options)
 		: abortEncode_(false), abortOutput_(false), index_(0), enc(encoded_, info), buf(encoded_),
-		  tcp_socket_("133.36.41.118", 4001), tcp_connected_(false)
+		  tcp_socket_("133.36.41.118", 4001), tcp_connected_(false),
+		  rtp_packetizer_(RTP_DST_HOST, RTP_DST_PORT)
 	{
 		tcp_connected_ = (tcp_socket_.create_client() >= 0);
 		if (!tcp_connected_)
 			LOG(1, "HT_Encoder: TCP connect to 133.36.41.118:4001 failed; will retry per frame");
+		if (!rtp_packetizer_.is_open())
+			LOG(1, "HT_Encoder: RTP UDP socket open failed for " << RTP_DST_HOST << ":" << RTP_DST_PORT);
 		output_thread_ = std::thread(&HT_Encoder::outputThread, this);
 		for (int i = 0; i < NUM_ENC_THREADS; i++)
 			encode_thread_[i] = std::thread(std::bind(&HT_Encoder::encodeThread, this, i));
@@ -111,6 +120,17 @@ private:
 				tcp_connected_ = (tcp_socket_.create_client() >= 0);
 			if (tcp_connected_)
 				tcp_socket_.Tx(buf.data(), buffer_len);
+
+			// Also fan out via RFC 9828 RTP for live monitoring. Independent
+			// of TCP archive — failure here doesn't affect the TCP path.
+			if (rtp_packetizer_.is_open())
+			{
+				// Camera timestamp is microseconds; RTP timestamp is 90 kHz ticks.
+				// us * 9 / 100 = us * 90 / 1000 with less overflow risk on int64.
+				const uint32_t ts90 = static_cast<uint32_t>(encode_item.timestamp_us * 9 / 100);
+				if (!rtp_packetizer_.send_codestream(buf.data(), buffer_len, ts90))
+					LOG(1, "HT_Encoder: RTP send_codestream failed for frame " << encode_item.index);
+			}
 			printf("HT codestream size = %ld, time = %f\n", buffer_len, encode_time);
 			frames++;
 			// Don't return buffers until the output thread as that's where they're
@@ -212,4 +232,5 @@ private:
 	std::vector<uint8_t> &buf;
 	simple_tcp tcp_socket_;
 	bool tcp_connected_;
+	RFC9828Packetizer rtp_packetizer_;
 };

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -60,11 +60,13 @@ public:
 		output_thread_.join();
 		LOG(2, "HT_Encoder closed");
 	}
-	// Encode the given buffer.
-	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
+	// Encode the given buffer.  RTP fans out every frame; TCP archive only
+	// fires when archive_this_frame is true (caller's rate-limit decision).
+	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us,
+					  bool archive_this_frame = false)
 	{
 		std::lock_guard<std::mutex> lock(encode_mutex_);
-		EncodeItem item = { mem, info, timestamp_us, index_++ };
+		EncodeItem item = { mem, info, timestamp_us, index_++, archive_this_frame };
 		encode_queue_.push(item);
 		encode_cond_var_.notify_all();
 	}
@@ -120,14 +122,8 @@ private:
 				// printf("\n");
 			}
 			encode_time = (std::chrono::high_resolution_clock::now() - start_time);
-			// send codestream via persistent TCP connection (retry connect if not yet up)
-			if (!tcp_connected_)
-				tcp_connected_ = (tcp_socket_.create_client() >= 0);
-			if (tcp_connected_)
-				tcp_socket_.Tx(buf.data(), buffer_len);
 
-			// Also fan out via RFC 9828 RTP for live monitoring. Independent
-			// of TCP archive — failure here doesn't affect the TCP path.
+			// RTP fan-out: every encoded frame, for continuous live monitoring.
 			if (rtp_packetizer_.is_open())
 			{
 				// Camera timestamp is microseconds; RTP timestamp is 90 kHz ticks.
@@ -135,6 +131,16 @@ private:
 				const uint32_t ts90 = static_cast<uint32_t>(encode_item.timestamp_us * 9 / 100);
 				if (!rtp_packetizer_.send_codestream(buf.data(), buffer_len, ts90))
 					LOG(1, "HT_Encoder: RTP send_codestream failed for frame " << encode_item.index);
+			}
+
+			// TCP archive: only when caller flagged this frame (e.g. person-detected
+			// + rate-limited).  Independent of the RTP path above.
+			if (encode_item.archive)
+			{
+				if (!tcp_connected_)
+					tcp_connected_ = (tcp_socket_.create_client() >= 0);
+				if (tcp_connected_)
+					tcp_socket_.Tx(buf.data(), buffer_len);
 			}
 			printf("HT codestream size = %ld, time = %f\n", buffer_len, encode_time);
 			frames++;
@@ -207,6 +213,7 @@ private:
 		StreamInfo info;
 		int64_t timestamp_us;
 		uint64_t index;
+		bool archive;
 	};
 	std::queue<EncodeItem> encode_queue_;
 	std::mutex encode_mutex_;

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -20,11 +20,6 @@
 #include "simple_tcp.hpp"
 #include "rfc9828_packetizer.hpp"
 
-// RFC 9828 RTP destination for live monitoring. Independent of the TCP archive
-// destination; receiver is osamu620/OpenHTJ2K's rtp_recv (default :6000).
-static constexpr const char *RTP_DST_HOST = "127.0.0.1";
-static constexpr int RTP_DST_PORT = 6000;
-
 uint8_t hotfix_for_mainheader[32] = { 0xFF, 0x4F, 0xFF, 0x51, 0x00, 0x2F, 0x40, 0x00, 0x00, 0x00, 0x07,
 									  0x80, 0x00, 0x00, 0x04, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 									  0x00, 0x00, 0x00, 0x00, 0x07, 0x80, 0x00, 0x00, 0x04, 0x38 };
@@ -34,13 +29,17 @@ public:
 	HT_Encoder(std::vector<uint8_t> &encoded_, const FrameInfo &info, Options const *options)
 		: abortEncode_(false), abortOutput_(false), index_(0), enc(encoded_, info), buf(encoded_),
 		  tcp_socket_("133.36.41.118", 4001), tcp_connected_(false),
-		  rtp_packetizer_(RTP_DST_HOST, RTP_DST_PORT)
+		  rtp_packetizer_(options->Get().rtp_host, options->Get().rtp_port)
 	{
 		tcp_connected_ = (tcp_socket_.create_client() >= 0);
 		if (!tcp_connected_)
 			LOG(1, "HT_Encoder: TCP connect to 133.36.41.118:4001 failed; will retry per frame");
 		if (!rtp_packetizer_.is_open())
-			LOG(1, "HT_Encoder: RTP UDP socket open failed for " << RTP_DST_HOST << ":" << RTP_DST_PORT);
+			LOG(1, "HT_Encoder: RTP UDP socket open failed for "
+					   << options->Get().rtp_host << ":" << options->Get().rtp_port);
+		else
+			LOG(2, "HT_Encoder: RTP fan-out -> " << options->Get().rtp_host << ":"
+												 << options->Get().rtp_port);
 		output_thread_ = std::thread(&HT_Encoder::outputThread, this);
 		for (int i = 0; i < NUM_ENC_THREADS; i++)
 			encode_thread_[i] = std::thread(std::bind(&HT_Encoder::encodeThread, this, i));

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -81,6 +81,14 @@ private:
 		std::chrono::duration<double> encode_time(0);
 		uint32_t frames = 0;
 
+		// Once-per-second rolling-stats accumulators (avoid per-frame printf
+		// at 30+ fps, which is itself measurable on the Pi).
+		auto stats_window_start = std::chrono::high_resolution_clock::now();
+		std::chrono::duration<double> stats_encode_total { 0 };
+		uint32_t stats_frames = 0;
+		uint64_t stats_bytes_total = 0;
+		uint32_t stats_archive_frames = 0;
+
 		EncodeItem encode_item;
 		while (true)
 		{
@@ -141,9 +149,35 @@ private:
 					tcp_connected_ = (tcp_socket_.create_client() >= 0);
 				if (tcp_connected_)
 					tcp_socket_.Tx(buf.data(), buffer_len);
+				++stats_archive_frames;
 			}
-			printf("HT codestream size = %ld, time = %f\n", buffer_len, encode_time);
+
+			// Per-frame line: only at verbose level 2.
+			LOG(2, "HT codestream size=" << buffer_len << " bytes, encode_time="
+										 << encode_time.count() * 1000.0 << " ms");
 			frames++;
+			stats_encode_total += encode_time;
+			++stats_frames;
+			stats_bytes_total += buffer_len;
+
+			// Once-per-second summary at default verbosity.
+			auto wall = std::chrono::high_resolution_clock::now();
+			auto window = std::chrono::duration<double>(wall - stats_window_start);
+			if (window.count() >= 1.0 && stats_frames > 0)
+			{
+				char line[160];
+				snprintf(line, sizeof(line),
+						 "%u fps, avg %.2f ms/frame, %.0f kbps, archived %u",
+						 stats_frames, stats_encode_total.count() * 1000.0 / stats_frames,
+						 (stats_bytes_total * 8.0 / 1000.0) / window.count(),
+						 stats_archive_frames);
+				LOG(1, "HT_Encoder: " << line);
+				stats_window_start = wall;
+				stats_encode_total = std::chrono::duration<double> { 0 };
+				stats_frames = 0;
+				stats_bytes_total = 0;
+				stats_archive_frames = 0;
+			}
 			// Don't return buffers until the output thread as that's where they're
 			// in order again.
 

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -29,7 +29,13 @@ public:
 	HT_Encoder(std::vector<uint8_t> &encoded_, const FrameInfo &info, Options const *options)
 		: abortEncode_(false), abortOutput_(false), index_(0), enc(encoded_, info), buf(encoded_),
 		  tcp_socket_("133.36.41.118", 4001), tcp_connected_(false),
-		  rtp_packetizer_(options->Get().rtp_host, options->Get().rtp_port)
+		  rtp_packetizer_(options->Get().rtp_host, options->Get().rtp_port,
+						  RFC9828Packetizer::Colorspace{
+							  /*colorspace_set=*/true,
+							  static_cast<uint8_t>(options->Get().rtp_prims),
+							  static_cast<uint8_t>(options->Get().rtp_trans),
+							  static_cast<uint8_t>(options->Get().rtp_mat),
+							  options->Get().rtp_range })
 	{
 		tcp_connected_ = (tcp_socket_.create_client() >= 0);
 		if (!tcp_connected_)

--- a/encoder/rfc9828_packetizer.hpp
+++ b/encoder/rfc9828_packetizer.hpp
@@ -1,0 +1,169 @@
+#pragma once
+
+// RFC 9828 RTP packetizer for HTJ2K codestreams.
+//
+// Wire format mirrors osamu620/OpenHTJ2K's source/apps/rtp_recv/rfc9828_parser.cpp:
+//   12-byte RTP fixed header (RFC 3550 §5.1) + 8-byte RFC 9828 Main or Body
+//   payload header + codestream chunk, one per UDP datagram.
+//
+// One frame = one Main packet (MH=3 single, or MH=2 followed by N Body
+// packets), marker bit on the last packet of the frame. PTSTAMP/ESEQ/POS/PID
+// are zero in this minimal packetizer (we don't emit sub-codestream timing or
+// resync points).
+
+#include <arpa/inet.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "simple_udp.hpp"
+
+class RFC9828Packetizer
+{
+public:
+	// ORDH constants from rfc9828_parser.hpp.
+	static constexpr uint8_t ORDH_LRCP_RESYNC = 1;
+	static constexpr uint8_t ORDH_RLCP_RESYNC = 2;
+	static constexpr uint8_t ORDH_RPCL_RESYNC = 3;
+	static constexpr uint8_t ORDH_PCRL_RESYNC = 4;
+	static constexpr uint8_t ORDH_CPRL_RESYNC = 5;
+	static constexpr uint8_t ORDH_PRCL_RESYNC = 6;
+
+	// MH constants.
+	static constexpr uint8_t MH_BODY = 0;
+	static constexpr uint8_t MH_MAIN_MORE_MAIN = 1;
+	static constexpr uint8_t MH_MAIN_THEN_BODY = 2;
+	static constexpr uint8_t MH_MAIN_SINGLE = 3;
+
+	// RTP-level constants. PT 96 is dynamic; SSRC is fixed per source.
+	static constexpr uint8_t RTP_VERSION = 2;
+	static constexpr uint8_t RTP_PT = 96;
+	static constexpr uint32_t RTP_SSRC = 0xCAFEBABEu;
+
+	// Conservative payload budget. Standard Ethernet MTU is 1500; subtracting
+	// 20 (IPv4) + 8 (UDP) leaves 1472. Use 1300 to stay safe under VPN/tunnel
+	// encapsulation and avoid IP fragmentation.
+	static constexpr size_t TARGET_DATAGRAM_BYTES = 1300;
+	static constexpr size_t RTP_HEADER_BYTES = 12;
+	static constexpr size_t MAIN_HEADER_BYTES = 8;
+	static constexpr size_t BODY_HEADER_BYTES = 8;
+
+	RFC9828Packetizer(const std::string &dst_host, int dst_port,
+					  uint8_t ordh = ORDH_RPCL_RESYNC)
+		: sock_(dst_host, dst_port), seq_(0), ordh_(ordh)
+	{
+	}
+
+	bool is_open() const { return sock_.is_open(); }
+
+	// Packetize and send one HTJ2K codestream as 1+N RTP datagrams.
+	// `timestamp90` is the per-frame 32-bit RTP timestamp (90 kHz); the same
+	// value is written into every packet of this frame.
+	bool send_codestream(const uint8_t *cs, size_t cs_len, uint32_t timestamp90)
+	{
+		if (!sock_.is_open() || cs == nullptr || cs_len == 0)
+			return false;
+
+		constexpr size_t MAIN_MAX = TARGET_DATAGRAM_BYTES - RTP_HEADER_BYTES - MAIN_HEADER_BYTES;
+		constexpr size_t BODY_MAX = TARGET_DATAGRAM_BYTES - RTP_HEADER_BYTES - BODY_HEADER_BYTES;
+
+		const bool single_main = (cs_len <= MAIN_MAX);
+		const uint8_t mh = single_main ? MH_MAIN_SINGLE : MH_MAIN_THEN_BODY;
+		const size_t main_chunk = single_main ? cs_len : MAIN_MAX;
+
+		if (!send_main_packet(cs, main_chunk, mh, timestamp90, /*marker=*/single_main))
+			return false;
+
+		size_t sent = main_chunk;
+		while (sent < cs_len)
+		{
+			const size_t remaining = cs_len - sent;
+			const size_t body_chunk = (remaining > BODY_MAX) ? BODY_MAX : remaining;
+			const bool last = (sent + body_chunk == cs_len);
+			if (!send_body_packet(cs + sent, body_chunk, timestamp90, /*marker=*/last))
+				return false;
+			sent += body_chunk;
+		}
+		return true;
+	}
+
+private:
+	bool send_main_packet(const uint8_t *cs_chunk, size_t chunk_len, uint8_t mh,
+						  uint32_t ts, bool marker)
+	{
+		std::vector<uint8_t> dg;
+		dg.reserve(RTP_HEADER_BYTES + MAIN_HEADER_BYTES + chunk_len);
+		write_rtp_header(dg, marker, ts);
+
+		// Byte 0: MH(2) | TP(3)=0 | ORDH(3)
+		dg.push_back(static_cast<uint8_t>(((mh & 0x03) << 6) | (ordh_ & 0x07)));
+		// Byte 1: P(1)=0 | XTRAC(3)=0 | PTSTAMP[11:8](4)=0
+		dg.push_back(0x00);
+		// Byte 2: PTSTAMP[7:0]=0
+		dg.push_back(0x00);
+		// Byte 3: ESEQ=0
+		dg.push_back(0x00);
+		// Byte 4: R=0 S=0 C=0 RSVD=0 RANGE=0
+		dg.push_back(0x00);
+		// Bytes 5-7: PRIMS=0 TRANS=0 MAT=0 (S=0, receiver uses --colorspace fallback)
+		dg.push_back(0x00);
+		dg.push_back(0x00);
+		dg.push_back(0x00);
+
+		dg.insert(dg.end(), cs_chunk, cs_chunk + chunk_len);
+		return sock_.sendto_one(dg.data(), dg.size());
+	}
+
+	bool send_body_packet(const uint8_t *cs_chunk, size_t chunk_len, uint32_t ts,
+						  bool marker)
+	{
+		std::vector<uint8_t> dg;
+		dg.reserve(RTP_HEADER_BYTES + BODY_HEADER_BYTES + chunk_len);
+		write_rtp_header(dg, marker, ts);
+
+		// Byte 0: MH(2)=0 | TP(3)=0 | RES(3)=0
+		dg.push_back(0x00);
+		// Byte 1: ORDB(1)=0 | QUAL(3)=0 | PTSTAMP[11:8](4)=0
+		dg.push_back(0x00);
+		// Byte 2: PTSTAMP[7:0]=0
+		dg.push_back(0x00);
+		// Byte 3: ESEQ=0
+		dg.push_back(0x00);
+		// Bytes 4-7: POS=0 PID=0 (ORDB=0 requires both)
+		dg.push_back(0x00);
+		dg.push_back(0x00);
+		dg.push_back(0x00);
+		dg.push_back(0x00);
+
+		dg.insert(dg.end(), cs_chunk, cs_chunk + chunk_len);
+		return sock_.sendto_one(dg.data(), dg.size());
+	}
+
+	void write_rtp_header(std::vector<uint8_t> &dg, bool marker, uint32_t ts)
+	{
+		// Byte 0: V=2 P=0 X=0 CC=0
+		dg.push_back(0x80);
+		// Byte 1: M | PT
+		dg.push_back(static_cast<uint8_t>((marker ? 0x80 : 0x00) | (RTP_PT & 0x7F)));
+		// Bytes 2-3: sequence (BE)
+		dg.push_back(static_cast<uint8_t>((seq_ >> 8) & 0xFF));
+		dg.push_back(static_cast<uint8_t>(seq_ & 0xFF));
+		// Bytes 4-7: timestamp (BE)
+		dg.push_back(static_cast<uint8_t>((ts >> 24) & 0xFF));
+		dg.push_back(static_cast<uint8_t>((ts >> 16) & 0xFF));
+		dg.push_back(static_cast<uint8_t>((ts >> 8) & 0xFF));
+		dg.push_back(static_cast<uint8_t>(ts & 0xFF));
+		// Bytes 8-11: SSRC (BE)
+		dg.push_back(static_cast<uint8_t>((RTP_SSRC >> 24) & 0xFF));
+		dg.push_back(static_cast<uint8_t>((RTP_SSRC >> 16) & 0xFF));
+		dg.push_back(static_cast<uint8_t>((RTP_SSRC >> 8) & 0xFF));
+		dg.push_back(static_cast<uint8_t>(RTP_SSRC & 0xFF));
+		++seq_;
+	}
+
+	simple_udp_client sock_;
+	uint16_t seq_;
+	uint8_t ordh_;
+};

--- a/encoder/rfc9828_packetizer.hpp
+++ b/encoder/rfc9828_packetizer.hpp
@@ -50,9 +50,21 @@ public:
 	static constexpr size_t MAIN_HEADER_BYTES = 8;
 	static constexpr size_t BODY_HEADER_BYTES = 8;
 
-	RFC9828Packetizer(const std::string &dst_host, int dst_port,
+	// H.273 colorspace fields written into the Main packet when colorspace_set
+	// is true (S=1 in the spec).  When colorspace_set is false (S=0), receivers
+	// fall back to their CLI/UI configuration to interpret the codestream.
+	struct Colorspace
+	{
+		bool colorspace_set = true;
+		uint8_t prims = 1;   // H.273 ColourPrimaries: 1 = BT.709 / sRGB
+		uint8_t trans = 13;  // H.273 TransferCharacteristics: 13 = sRGB
+		uint8_t mat = 5;     // H.273 MatrixCoefficients: 5 = BT.470BG / BT.601 525
+		bool full_range = true;
+	};
+
+	RFC9828Packetizer(const std::string &dst_host, int dst_port, Colorspace cs,
 					  uint8_t ordh = ORDH_RPCL_RESYNC)
-		: sock_(dst_host, dst_port), seq_(0), ordh_(ordh)
+		: sock_(dst_host, dst_port), seq_(0), ordh_(ordh), cs_(cs)
 	{
 	}
 
@@ -105,12 +117,25 @@ private:
 		dg.push_back(0x00);
 		// Byte 3: ESEQ=0
 		dg.push_back(0x00);
-		// Byte 4: R=0 S=0 C=0 RSVD=0 RANGE=0
-		dg.push_back(0x00);
-		// Bytes 5-7: PRIMS=0 TRANS=0 MAT=0 (S=0, receiver uses --colorspace fallback)
-		dg.push_back(0x00);
-		dg.push_back(0x00);
-		dg.push_back(0x00);
+		// Byte 4: R(1)=0 | S(1) | C(1)=0 | RSVD(4)=0 | RANGE(1)
+		// Bytes 5-7: PRIMS, TRANS, MAT (per H.273; meaningful only when S=1).
+		// When S=0 the spec requires bytes 4..7 to be all zero, so we hand-build
+		// either layout here.
+		if (cs_.colorspace_set)
+		{
+			uint8_t b4 = static_cast<uint8_t>(0x40 /* S=1 */ | (cs_.full_range ? 0x01 : 0x00));
+			dg.push_back(b4);
+			dg.push_back(cs_.prims);
+			dg.push_back(cs_.trans);
+			dg.push_back(cs_.mat);
+		}
+		else
+		{
+			dg.push_back(0x00);
+			dg.push_back(0x00);
+			dg.push_back(0x00);
+			dg.push_back(0x00);
+		}
 
 		dg.insert(dg.end(), cs_chunk, cs_chunk + chunk_len);
 		return sock_.sendto_one(dg.data(), dg.size());
@@ -166,4 +191,5 @@ private:
 	simple_udp_client sock_;
 	uint16_t seq_;
 	uint8_t ordh_;
+	Colorspace cs_;
 };

--- a/encoder/simple_udp.hpp
+++ b/encoder/simple_udp.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <string>
+
+class simple_udp_client
+{
+	int sockfd;
+	sockaddr_in dst_addr;
+
+public:
+	simple_udp_client(const std::string &host, int port) : sockfd(-1)
+	{
+		sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+		memset(&dst_addr, 0, sizeof(dst_addr));
+		dst_addr.sin_family = AF_INET;
+		dst_addr.sin_addr.s_addr = inet_addr(host.c_str());
+		dst_addr.sin_port = htons(port);
+		// Larger send buffer keeps full-frame bursts from blocking.
+		int sndbuf = 8 * 1024 * 1024;
+		setsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+	}
+
+	~simple_udp_client() { destroy(); }
+
+	void destroy()
+	{
+		if (sockfd >= 0)
+		{
+			close(sockfd);
+			sockfd = -1;
+		}
+	}
+
+	bool is_open() const { return sockfd >= 0; }
+
+	bool sendto_one(const uint8_t *data, size_t len)
+	{
+		if (sockfd < 0)
+			return false;
+		ssize_t n = sendto(sockfd, data, len, 0, reinterpret_cast<sockaddr *>(&dst_addr),
+						   sizeof(dst_addr));
+		return n == static_cast<ssize_t>(len);
+	}
+};


### PR DESCRIPTION
## Summary

Restructures the live-monitoring + archive split so the two paths serve their natural use cases independently.

**Before this PR:** the HAILO person-detection gate decided whether `HT_Encoder::EncodeBuffer` got called at all. Both the RTP fan-out (introduced in #11) and the TCP archive only saw frames during detection events.

**After this PR:**

- **RTP fans out every encoded frame.** The receiver gets a continuous timestamp progression, the auto-pacer in `rtp_recv` can schedule presents from RTP-timestamp deltas, and an empty pre-detection scene is visually indistinguishable from a "camera is alive" idle view rather than a "camera is dead" silence.
- **TCP archive only fires when a person is detected AND ≥ `--archive-min-interval-ms` (default 1000) since the last archive snapshot.** 1 fps is plenty of resolution for the search-by-time GUI on the Mongo-indexed archive without flooding disk and Mongo at full encoder rate.

Implementation:

- `HT_Encoder::EncodeBuffer(...)` grows a `bool archive_this_frame` parameter (default `false`). The encoder thread RTP-fans-out unconditionally; TCP send is gated on that flag.
- `apps/rpicam_hello.cpp` event loop calls `EncodeBuffer` on **every** frame regardless of detection, computes `archive_this_frame = person_detected && (now_us - last_archive_us >= interval_us)`, and updates `last_archive_us` only when it archived.
- New CLI option `--archive-min-interval-ms` (default 1000).

**Incidental fix:** the previous call site passed `0` for `timestamp_us`, so every RTP packet had timestamp 0 and the receiver's RTP-timestamp pacer had nothing to work with. The new call site passes a real microsecond timestamp from `std::chrono::high_resolution_clock`, which the encoder converts to 90 kHz ticks for the RTP header.

**Logging cleanup (second commit):** with continuous RTP, the per-frame `printf("HT codestream size = %ld, time = %f")` was running at 30+ fps and was itself a measurable time sink on the Pi (per-frame write(2) + stdio buffering). Replaced with `LOG(2, ...)` per frame (verbose-only) plus a `LOG(1, ...)` once-per-second rolling summary: `fps, avg ms/frame, kbps, archived N`. Default-verbosity output drops from 30 lines/sec to 1 line/sec without losing operational info.

## Stacking / dependencies

Branched off `feat/rfc9828-packetizer` (#11). The decouple change only makes sense once the RTP path exists. Targeting #11's branch as the merge base — once #11 merges to `main`, this PR rebases onto `main` automatically.

## Test plan

- [x] `meson compile -C build` clean (all 38 targets rebuild without warnings)
- [x] `--archive-min-interval-ms` exposed in `--help` with the right default
- [ ] End-to-end on the Pi against the live receiver on `192.168.0.14`: confirm continuous frame flow during idle (no person), and that exactly ≤ 1 archive snapshot lands per second on `133.36.41.118` while a person is in frame
- [ ] Verify the once-per-second `HT_Encoder: N fps, avg X ms/frame, Y kbps, archived M` line is visible at default verbosity and the per-frame line goes silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)