### PR TITLE
Decouple RTP fan-out from the person-detection gate

### DIFF
--- a/apps/rpicam_hello.cpp
+++ b/apps/rpicam_hello.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <chrono>
+#include <limits>
 
 #include "core/options.hpp"
 #include "core/rpicam_app.hpp"
@@ -46,6 +47,10 @@ static void event_loop(RPiCamApp &app)
 
 	app.StartCamera();
 
+	const int64_t archive_interval_us =
+		static_cast<int64_t>(options->Get().archive_min_interval_ms) * 1000;
+	int64_t last_archive_us = std::numeric_limits<int64_t>::min();
+
 	auto start_time = std::chrono::high_resolution_clock::now();
 	for (unsigned int count = 0;; count++)
 	{
@@ -72,17 +77,23 @@ static void event_loop(RPiCamApp &app)
 
 		std::vector<Detection> objects;
 		completed_request->post_process_metadata.Get("object_detect.results", objects);
-		bool encode = false;
+		bool person_detected = false;
 		for (auto const &v : objects)
 		{
 			if (v.name == "person" && v.confidence > 0.75)
 			{
-				encode = true;
+				person_detected = true;
 				break;
 			}
 		}
-		if (!encode)
-			continue;
+
+		const int64_t now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+									now.time_since_epoch())
+									.count();
+		const bool archive_this_frame =
+			person_detected && (now_us - last_archive_us >= archive_interval_us);
+		if (archive_this_frame)
+			last_archive_us = now_us;
 
 		libcamera::Stream *stream = app.ViewfinderStream();
 		BufferReadSync r(&app, completed_request->buffers[stream]);
@@ -90,7 +101,8 @@ static void event_loop(RPiCamApp &app)
 		const int w = options->Get().viewfinder_width;
 		const int h = options->Get().viewfinder_height;
 		cv::Mat frame(h * 3 / 2, w, CV_8UC1, buffer.data());
-		htenc.EncodeBuffer(1, w * h * 3 / 2, frame.data, app.GetStreamInfo(stream), 0);
+		htenc.EncodeBuffer(1, w * h * 3 / 2, frame.data, app.GetStreamInfo(stream), now_us,
+						   archive_this_frame);
 	}
 }
 

--- a/apps/rpicam_hello.cpp
+++ b/apps/rpicam_hello.cpp
@@ -47,8 +47,7 @@ static void event_loop(RPiCamApp &app)
 
 	app.StartCamera();
 
-	const int64_t archive_interval_us =
-		static_cast<int64_t>(options->Get().archive_min_interval_ms) * 1000;
+	const int64_t archive_interval_us = static_cast<int64_t>(options->Get().archive_min_interval_ms) * 1000;
 	int64_t last_archive_us = std::numeric_limits<int64_t>::min();
 
 	auto start_time = std::chrono::high_resolution_clock::now();
@@ -87,11 +86,8 @@ static void event_loop(RPiCamApp &app)
 			}
 		}
 
-		const int64_t now_us = std::chrono::duration_cast<std::chrono::microseconds>(
-									now.time_since_epoch())
-									.count();
-		const bool archive_this_frame =
-			person_detected && (now_us - last_archive_us >= archive_interval_us);
+		const int64_t now_us = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+		const bool archive_this_frame = person_detected && (now_us - last_archive_us >= archive_interval_us);
 		if (archive_this_frame)
 			last_archive_us = now_us;
 
@@ -101,8 +97,7 @@ static void event_loop(RPiCamApp &app)
 		const int w = options->Get().viewfinder_width;
 		const int h = options->Get().viewfinder_height;
 		cv::Mat frame(h * 3 / 2, w, CV_8UC1, buffer.data());
-		htenc.EncodeBuffer(1, w * h * 3 / 2, frame.data, app.GetStreamInfo(stream), now_us,
-						   archive_this_frame);
+		htenc.EncodeBuffer(1, w * h * 3 / 2, frame.data, app.GetStreamInfo(stream), now_us, archive_this_frame);
 	}
 }
 

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -251,6 +251,8 @@ Options::Options()
 			"H.273 MatrixCoefficients written to the RTP Main packet (default 5 = BT.470BG/BT.601 525)")
 		("rtp-range", value<bool>(&v_->rtp_range)->default_value(true)->implicit_value(true),
 			"RTP VideoFullRangeFlag (default true = full range; false = narrow/limited)")
+		("archive-min-interval-ms", value<int>(&v_->archive_min_interval_ms)->default_value(1000),
+			"Minimum spacing between TCP archive snapshots when a person is detected, in ms (default 1000)")
 		("nopreview,n", value<bool>(&v_->nopreview)->default_value(false)->implicit_value(true),
 			"Do not show a preview window")
 		("preview,p", value<std::string>(&v_->preview)->default_value("0,0,0,0"),

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -345,6 +345,9 @@ struct OptsInternal
 	int rtp_trans;
 	int rtp_mat;
 	bool rtp_range;
+	// Minimum spacing between TCP archive snapshots when person-detected.
+	// Independent of the RTP fan-out, which runs every encoded frame.
+	int archive_min_interval_ms;
 };
 
 struct Options

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -78,6 +78,14 @@ private:
 		std::chrono::duration<double> encode_time(0);
 		uint32_t frames = 0;
 
+		// Once-per-second rolling-stats accumulators (avoid per-frame printf
+		// at 30+ fps, which is itself measurable on the Pi).
+		auto stats_window_start = std::chrono::high_resolution_clock::now();
+		std::chrono::duration<double> stats_encode_total { 0 };
+		uint32_t stats_frames = 0;
+		uint64_t stats_bytes_total = 0;
+		uint32_t stats_archive_frames = 0;
+
 		EncodeItem encode_item;
 		while (true)
 		{
@@ -146,9 +154,33 @@ private:
 						tcp_connected_ = false;
 					}
 				}
+				++stats_archive_frames;
 			}
-			printf("HT codestream size = %ld, time = %f\n", buffer_len, encode_time);
+
+			// Per-frame line: only at verbose level 2.
+			LOG(2,
+				"HT codestream size=" << buffer_len << " bytes, encode_time=" << encode_time.count() * 1000.0 << " ms");
 			frames++;
+			stats_encode_total += encode_time;
+			++stats_frames;
+			stats_bytes_total += buffer_len;
+
+			// Once-per-second summary at default verbosity.
+			auto wall = std::chrono::high_resolution_clock::now();
+			auto window = std::chrono::duration<double>(wall - stats_window_start);
+			if (window.count() >= 1.0 && stats_frames > 0)
+			{
+				char line[160];
+				snprintf(line, sizeof(line), "%u fps, avg %.2f ms/frame, %.0f kbps, archived %u", stats_frames,
+						 stats_encode_total.count() * 1000.0 / stats_frames,
+						 (stats_bytes_total * 8.0 / 1000.0) / window.count(), stats_archive_frames);
+				LOG(1, "HT_Encoder: " << line);
+				stats_window_start = wall;
+				stats_encode_total = std::chrono::duration<double> { 0 };
+				stats_frames = 0;
+				stats_bytes_total = 0;
+				stats_archive_frames = 0;
+			}
 			// Don't return buffers until the output thread as that's where they're
 			// in order again.
 

--- a/encoder/ht_encoder.hpp
+++ b/encoder/ht_encoder.hpp
@@ -57,11 +57,13 @@ public:
 		output_thread_.join();
 		LOG(2, "HT_Encoder closed");
 	}
-	// Encode the given buffer.
-	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
+	// Encode the given buffer.  RTP fans out every frame; TCP archive only
+	// fires when archive_this_frame is true (caller's rate-limit decision).
+	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us,
+					  bool archive_this_frame = false)
 	{
 		std::lock_guard<std::mutex> lock(encode_mutex_);
-		EncodeItem item = { mem, info, timestamp_us, index_++ };
+		EncodeItem item = { mem, info, timestamp_us, index_++, archive_this_frame };
 		encode_queue_.push(item);
 		encode_cond_var_.notify_all();
 	}
@@ -117,22 +119,8 @@ private:
 				// printf("\n");
 			}
 			encode_time = (std::chrono::high_resolution_clock::now() - start_time);
-			// Send codestream via persistent TCP connection, framed as [u32 BE length][N bytes].
-			// On failure, drop the socket and reconnect on the next frame.
-			if (!tcp_connected_)
-				tcp_connected_ = (tcp_socket_.create_client() >= 0);
-			if (tcp_connected_)
-			{
-				if (!tcp_socket_.SendFramed(buf.data(), static_cast<uint32_t>(buffer_len)))
-				{
-					LOG(1, "HT_Encoder: TCP send failed; reconnecting on next frame");
-					tcp_socket_.destroy();
-					tcp_connected_ = false;
-				}
-			}
 
-			// Also fan out via RFC 9828 RTP for live monitoring. Independent
-			// of TCP archive — failure here doesn't affect the TCP path.
+			// RTP fan-out: every encoded frame, for continuous live monitoring.
 			if (rtp_packetizer_.is_open())
 			{
 				// Camera timestamp is microseconds; RTP timestamp is 90 kHz ticks.
@@ -140,6 +128,24 @@ private:
 				const uint32_t ts90 = static_cast<uint32_t>(encode_item.timestamp_us * 9 / 100);
 				if (!rtp_packetizer_.send_codestream(buf.data(), buffer_len, ts90))
 					LOG(1, "HT_Encoder: RTP send_codestream failed for frame " << encode_item.index);
+			}
+
+			// TCP archive: only when caller flagged this frame (e.g. person-detected
+			// + rate-limited).  Uses the persistent length-framed send from stage 1;
+			// independent of the RTP path above.
+			if (encode_item.archive)
+			{
+				if (!tcp_connected_)
+					tcp_connected_ = (tcp_socket_.create_client() >= 0);
+				if (tcp_connected_)
+				{
+					if (!tcp_socket_.SendFramed(buf.data(), static_cast<uint32_t>(buffer_len)))
+					{
+						LOG(1, "HT_Encoder: TCP send failed; reconnecting on next frame");
+						tcp_socket_.destroy();
+						tcp_connected_ = false;
+					}
+				}
 			}
 			printf("HT codestream size = %ld, time = %f\n", buffer_len, encode_time);
 			frames++;
@@ -212,6 +218,7 @@ private:
 		StreamInfo info;
 		int64_t timestamp_us;
 		uint64_t index;
+		bool archive;
 	};
 	std::queue<EncodeItem> encode_queue_;
 	std::mutex encode_mutex_;


### PR DESCRIPTION
Replaces #12, which auto-closed when its base branch `feat/rfc9828-packetizer` was deleted on merge of #11. This PR is the same content, rebased onto `main`.

## Summary

Restructures the live-monitoring + archive split so the two paths serve their natural use cases independently.

**Before:** the HAILO person-detection gate decided whether `HT_Encoder::EncodeBuffer` got called at all. Both the RTP fan-out (introduced in #11) and the TCP archive only saw frames during detection events.

**After:**

- **RTP fans out every encoded frame** — the receiver gets a continuous timestamp progression, the auto-pacer in `rtp_recv` can schedule presents from RTP-timestamp deltas, and an empty pre-detection scene is visually indistinguishable from "camera is alive idle" rather than "camera is dead silent."
- **TCP archive only fires when a person is detected AND ≥ `--archive-min-interval-ms` (default 1000) since the last archive snapshot.** 1 fps is plenty for the search-by-time GUI on the Mongo-indexed archive without flooding disk and Mongo at full encoder rate.

Implementation:

- `HT_Encoder::EncodeBuffer(...)` grows a `bool archive_this_frame` parameter (default `false`). The encoder thread RTP-fans-out unconditionally; TCP send is gated on that flag and uses the persistent length-framed `SendFramed` from #10.
- `apps/rpicam_hello.cpp` event loop calls `EncodeBuffer` on **every** frame regardless of detection, computes `archive_this_frame = person_detected && (now_us - last_archive_us >= interval_us)`, and updates `last_archive_us` only when it archived.
- New CLI option `--archive-min-interval-ms` (default 1000).

**Incidental fix:** the previous call site passed `0` for `timestamp_us`, so every RTP packet had timestamp 0 and the receiver's RTP-timestamp pacer had nothing to work with. The new call site passes a real microsecond timestamp from `std::chrono::high_resolution_clock`, which the encoder converts to 90 kHz ticks for the RTP header.

**Logging cleanup (second commit):** with continuous RTP, the per-frame `printf("HT codestream size = %ld, time = %f")` was running at 30+ fps and was itself a measurable time sink on the Pi (per-frame write(2) + stdio buffering). Replaced with `LOG(2, ...)` per frame (verbose-only) plus a `LOG(1, ...)` once-per-second rolling summary: `fps, avg ms/frame, kbps, archived N`. Default-verbosity output drops from 30 lines/sec to 1 line/sec without losing operational info.

## Test plan

- [x] `meson compile -C build` clean (all 38 targets rebuild without warnings)
- [x] `--archive-min-interval-ms` exposed in `--help` with the right default
- [x] Rebased onto post-#11 `main`; ht_encoder.hpp conflict resolution preserves both stage 1's framed `SendFramed` and the new `archive_this_frame` gate
- [ ] End-to-end on the Pi against the live receiver on `192.168.0.14`: continuous frame flow during idle (no person), and ≤ 1 archive snapshot per second on `133.36.41.118` while a person is in frame
- [ ] Verify the once-per-second `HT_Encoder: N fps, avg X ms/frame, Y kbps, archived M` line is visible at default verbosity and the per-frame line is silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)